### PR TITLE
New native type example

### DIFF
--- a/build_lib.py
+++ b/build_lib.py
@@ -164,6 +164,7 @@ try:
         "native/volume.cpp",
         "native/marching.cpp",
         "native/cutlass_gemm.cpp",
+        "native/foo.cpp",
     ]
     warp_cpp_paths = [os.path.join(build_path, cpp) for cpp in cpp_sources]
 

--- a/tmp/test_foo.py
+++ b/tmp/test_foo.py
@@ -1,0 +1,83 @@
+import warp as wp
+from warp.foo import Foo
+
+
+# Kernel that accesses Foo variables by name
+@wp.kernel
+def foo_vars_kernel(foo_id: wp.uint64, a: wp.array(dtype=float)):
+    i = wp.tid()
+
+    foo = wp.foo_get(foo_id)
+
+    a[i] = foo.magic + float(foo.offset)
+
+
+# Kernel that demonstrates 1d indexing of Foo
+@wp.kernel
+def foo_index_1d_kernel(foo_id: wp.uint64, a: wp.array(dtype=float)):
+    i = wp.tid()
+
+    foo = wp.foo_get(foo_id)
+
+    a[i] = foo[i]
+
+
+# Kernel that demonstrates 2d indexing of Foo
+@wp.kernel
+def foo_index_2d_kernel(foo_id: wp.uint64, a: wp.array2d(dtype=float)):
+    i, j = wp.tid()
+
+    foo = wp.foo_get(foo_id)
+
+    a[i, j] = foo[i, j]
+
+
+def test_foo_vars():
+    a = wp.zeros(10, dtype=float)
+
+    foo = Foo(magic=0.5, offset=3)
+
+    wp.launch(foo_vars_kernel, dim=a.size, inputs=[foo.id, a])
+    print(a)
+
+
+def test_foo_index_1d():
+    a = wp.zeros(10, dtype=float)
+
+    foo = Foo(magic=0.1)
+
+    wp.launch(foo_index_1d_kernel, dim=a.size, inputs=[foo.id, a])
+    print(a)
+
+
+def test_foo_index_2d():
+    a = wp.zeros((10, 10), dtype=float)
+
+    foo = Foo(offset=5)
+
+    wp.launch(foo_index_2d_kernel, dim=a.shape, inputs=[foo.id, a])
+    print(a)
+
+
+def run_tests(device):
+    print(f"===== Device {device} ====================")
+    with wp.ScopedDevice(device):
+        print("Test vars:")
+        test_foo_vars()
+
+        print("Test 1d indexing:")
+        test_foo_index_1d()
+
+        print("Test 2d indexing:")
+        test_foo_index_2d()
+
+
+wp.init()
+
+# it's useful to clear the kernel cache when developing new codegen features
+wp.build.clear_kernel_cache()
+
+wp.force_load(device=["cpu", "cuda:0"])
+
+run_tests("cpu")
+run_tests("cuda:0")

--- a/warp/builtins.py
+++ b/warp/builtins.py
@@ -1900,6 +1900,39 @@ add_builtin(
     doc="Tests for intersection between two triangles (v0, v1, v2) and (u0, u1, u2) using Moller's method. Returns > 0 if triangles intersect.",
 )
 
+from warp.foo import Foo
+
+# implements foo = wp.foo_get(id)
+add_builtin(
+    "foo_get",
+    input_types={"id": uint64},
+    value_type=Foo,
+    missing_grad=True,
+    group="Utility",
+    doc="""Retrieves the Foo given its id.""",
+)
+
+# implements foo[i]
+add_builtin(
+    "extract",
+    input_types={"foo": Foo, "i": int},
+    value_type=float,
+    hidden=True,
+    group="Utility",
+    skip_replay=True,
+)
+
+# implements foo[i, j]
+add_builtin(
+    "extract",
+    input_types={"foo": Foo, "i": int, "j": int},
+    value_type=float,
+    hidden=True,
+    group="Utility",
+    skip_replay=True,
+)
+
+
 add_builtin(
     "mesh_get",
     input_types={"id": uint64},

--- a/warp/context.py
+++ b/warp/context.py
@@ -2259,6 +2259,19 @@ class Runtime:
             ctypes.c_int,
         ]
 
+        # bindings for Foo API on CPU
+        self.core.foo_create_host.argtypes = [ctypes.c_float, ctypes.c_int]
+        self.core.foo_create_host.restype = ctypes.c_uint64
+        self.core.foo_destroy_host.argtypes = [ctypes.c_uint64]
+        self.core.foo_destroy_host.restype = None
+
+        # bindings for Foo API on GPU
+        self.core.foo_create_device.argtypes = [ctypes.c_void_p, ctypes.c_float, ctypes.c_int]
+        self.core.foo_create_device.restype = ctypes.c_uint64
+        self.core.foo_destroy_device.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+        self.core.foo_destroy_device.restype = None
+
+
         self.core.bvh_create_host.restype = ctypes.c_uint64
         self.core.bvh_create_host.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
 

--- a/warp/foo.py
+++ b/warp/foo.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 NVIDIA CORPORATION.  All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+import warp
+
+class Foo:
+
+    from warp.codegen import Var
+
+    # named variables accessible in kernels, e.g. foo.magic
+    vars = {
+        "magic": Var("magic", warp.float32),
+        "offset": Var("offset", warp.int32),
+    }
+
+    def __init__(self, magic: float = 0.0, offset: int = 0, device = None):
+
+        self.id = 0
+
+        self.device = warp.get_device(device)
+        self.runtime = warp.context.runtime
+
+        # create on the specified device
+        if self.device.is_cuda:
+            self.id = self.runtime.core.foo_create_device(self.device.context, magic, offset)
+        else:
+            self.id = self.runtime.core.foo_create_host(magic, offset)
+
+    def __del__(self):
+
+        if not self.id:
+            return
+        
+        # release on the specified device
+        if self.device.is_cuda:
+            self.runtime.core.foo_destroy_device(self.device.context, self.id)
+        else:
+            self.runtime.core.foo_destroy_host(self.id)

--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -1546,3 +1546,4 @@ inline CUDA_CALLABLE void adj_expect_near(const vec3& actual, const vec3& expect
 #include "rand.h"
 #include "noise.h"
 #include "matnn.h"
+#include "foo.h"

--- a/warp/native/foo.cpp
+++ b/warp/native/foo.cpp
@@ -1,0 +1,42 @@
+/** Copyright (c) 2024 NVIDIA CORPORATION.  All rights reserved.
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
+#include "foo.h"
+
+// API definitions
+extern "C"
+{
+
+WP_API uint64_t foo_create_host(float magic, int offset)
+{
+    wp::Foo* foo = new wp::Foo(magic, offset);
+    return (uint64_t)foo;
+}
+
+WP_API void foo_destroy_host(uint64_t id)
+{
+    wp::Foo* foo = (wp::Foo*)id;
+    delete foo;
+}
+
+// stubs for non-CUDA platforms
+#if !WP_ENABLE_CUDA
+
+WP_API uint64_t foo_create_device(void* context, float magic, int offset)
+{
+    return 0;
+}
+
+WP_API void foo_destroy_device(void* context, uint64_t id)
+{
+}
+
+// end stubs
+#endif
+
+} // end extern "C"

--- a/warp/native/foo.cu
+++ b/warp/native/foo.cu
@@ -1,0 +1,87 @@
+/** Copyright (c) 2024 NVIDIA CORPORATION.  All rights reserved.
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
+#include "foo.h"
+#include "warp.h"
+#include "cuda_util.h"
+
+#include <unordered_map>
+
+namespace
+{
+
+// host-side copy of Foo descriptors, maps GPU Foo id (address) to the CPU desc
+std::unordered_map<uint64_t, wp::Foo> g_foo_descriptors;
+
+bool foo_get_descriptor(uint64_t id, wp::Foo& foo)
+{
+    auto iter = g_foo_descriptors.find(id);
+    if (iter != g_foo_descriptors.end())
+    {
+        foo = iter->second;
+        return true;
+    }
+    return false;
+}
+
+void foo_add_descriptor(uint64_t id, const wp::Foo& foo)
+{
+    g_foo_descriptors[id] = foo;
+}
+
+void foo_rem_descriptor(uint64_t id)
+{
+    g_foo_descriptors.erase(id);
+}
+
+} // end anonymous namespace
+
+
+// API definitions
+extern "C"
+{
+
+WP_API uint64_t foo_create_device(void* context, float magic, int offset)
+{
+    // use the specified CUDA context
+    ContextGuard guard(context);
+
+    // create Foo descriptor
+    wp::Foo foo(magic, offset);
+
+    // remember the context
+    foo.context = context ? context : cuda_context_get_current();
+
+    // allocate and copy to the GPU
+    void* foo_d = alloc_device(WP_CURRENT_CONTEXT, sizeof(wp::Foo));
+    memcpy_h2d(WP_CURRENT_CONTEXT, foo_d, &foo, sizeof(wp::Foo));
+
+    // save descriptor
+    uint64_t id = (uint64_t)foo_d;
+    foo_add_descriptor(id, foo);
+
+    return id;
+}
+
+WP_API void foo_destroy_device(void* context, uint64_t id)
+{
+    wp::Foo foo;
+    if (foo_get_descriptor(id, foo))
+    {
+        // use the specified CUDA context
+        ContextGuard guard(foo.context);
+
+        // free GPU memory
+        free_device(WP_CURRENT_CONTEXT, (void*)id);
+
+        // remove descriptor
+        foo_rem_descriptor(id);
+    }
+}
+
+} // end of extern "C"

--- a/warp/native/foo.h
+++ b/warp/native/foo.h
@@ -1,0 +1,64 @@
+/** Copyright (c) 2024 NVIDIA CORPORATION.  All rights reserved.
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
+#pragma once
+
+#include "builtin.h"
+
+namespace wp
+{
+
+struct Foo
+{
+    // member variables (will be exposed to kernels, e.g. foo.magic)
+    float magic;
+    int offset;
+
+    // CUDA context (NULL on CPU)
+    void* context;
+
+    CUDA_CALLABLE Foo()
+        : magic(0.0f), offset(0), context(nullptr)
+    {
+    }
+
+    CUDA_CALLABLE Foo(float magic, int offset)
+        : magic(magic), offset(offset), context(nullptr)
+    {
+    }
+};
+
+// implements foo = wp.get_foo(id)
+CUDA_CALLABLE inline Foo foo_get(uint64_t id)
+{
+    return *(Foo*)(id);
+}
+
+// implements foo[i]
+CUDA_CALLABLE inline float extract(const Foo& foo, int i)
+{
+    return 2.0f * i + foo.magic;
+}
+
+// implements foo[i, j]
+CUDA_CALLABLE inline float extract(const Foo& foo, int i, int j)
+{
+    return (float)(i + j + foo.offset);
+}
+
+// backward foo[i]
+CUDA_CALLABLE inline void adj_extract(const Foo& foo, int i, const Foo& adj_foo, int adj_i, int adj_ret)
+{
+}
+
+// backward foo[i, j]
+CUDA_CALLABLE inline void adj_extract(const Foo& foo, int i, int j, const Foo& adj_foo, int adj_i, int adj_j, int adj_ret)
+{
+}
+
+}

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -1983,6 +1983,7 @@ void cuda_graphics_unregister_resource(void* context, void* resource)
 #if WP_ENABLE_CUTLASS
     #include "cutlass_gemm.cu"
 #endif
+#include "foo.cu"
 
 //#include "spline.inl"
 //#include "volume.inl"

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -54,6 +54,14 @@ extern "C"
     WP_API void memtile_host(void* dest, const void* src, size_t srcsize, size_t n);
     WP_API void memtile_device(void* context, void* dest, const void* src, size_t srcsize, size_t n);
 
+    // Foo API on CPU
+    WP_API uint64_t foo_create_host(float magic, int offset);
+    WP_API void foo_destroy_host(uint64_t id);
+
+    // Foo API on GPU
+    WP_API uint64_t foo_create_device(void* context, float magic, int offset);
+    WP_API void foo_destroy_device(void* context, uint64_t id);
+
 	WP_API uint64_t bvh_create_host(wp::vec3* lowers, wp::vec3* uppers, int num_items);
 	WP_API void bvh_destroy_host(uint64_t id);
     WP_API void bvh_refit_host(uint64_t id);


### PR DESCRIPTION
Adds a new native type `Foo` that can be used in Warp kernels.